### PR TITLE
Fix missing PIDFile directive in systemd unit file

### DIFF
--- a/debian/keepalived.service
+++ b/debian/keepalived.service
@@ -8,6 +8,7 @@ ConditionFileNotEmpty=/etc/keepalived/keepalived.conf
 [Service]
 Type=forking
 KillMode=process
+PIDFile=/var/run/keepalived.pid
 # Read configuration variable file if it is present
 EnvironmentFile=-/etc/default/keepalived
 ExecStart=/usr/sbin/keepalived $DAEMON_ARGS


### PR DESCRIPTION
As described in https://github.com/acassen/keepalived/issues/443, keepalived in Ubuntu/Debian sometimes fails to stop/restart cleanly. The old processes remain with the old settings and cause unexpected behaviors. This pull request simply adds the `PIDFile=` directive to fix this problem.

Ubuntu bug: https://bugs.launchpad.net/ubuntu/+source/keepalived/+bug/1644530